### PR TITLE
Fix V3006

### DIFF
--- a/Src/NCCommon/Configuration/ConfigurationBuilder.cs
+++ b/Src/NCCommon/Configuration/ConfigurationBuilder.cs
@@ -193,11 +193,9 @@ namespace Alachisoft.NCache.Common.Configuration
             }
             catch (Exception e)
             {
-                new Exception("Can not open " + fileName + " Error:" + e.ToString());
+                throw new Exception("Can not open " + fileName + " Error:" + e.ToString());
             }
-
-			ReadConfiguration(document);
-
+	    ReadConfiguration(document);
         }
 
 		public void ReadConfiguration(XmlDocument xmlDocument)


### PR DESCRIPTION
Hello again from Pinguem.ru competition on finding errors. I found some more bugs with PVS-Studio:

- The object was created but it is not being used. The 'throw' keyword could be missing: throw new Exception(FOO). NCCommon ConfigurationBuilder.cs 196