### PR TITLE
Fix V3013

### DIFF
--- a/Src/NCCache/Caching/Queries/NCQLParserRule.cs
+++ b/Src/NCCache/Caching/Queries/NCQLParserRule.cs
@@ -72,7 +72,7 @@ namespace Alachisoft.NCache.Caching.Queries
         public Reduction CreateRULE_DELETEPARAMS_DOLLARTEXTDOLLAR(Reduction reduction)
         {
             reduction.Tag = "System.String";
-            if (NCacheLog.IsInfoEnabled) NCacheLog.Info("CreateRULE_OBJECTTYPE_DOLLARTEXTDOLLAR");
+            if (NCacheLog.IsInfoEnabled) NCacheLog.Info("CreateRULE_DELETEPARAMS_DOLLARTEXTDOLLAR");
             return null;
         }
 


### PR DESCRIPTION
Another bug fixes from Pinguem.ru competition found with PVS-Studio:

- It is odd that the body of 'CreateRULE_DELETEPARAMS_DOLLARTEXTDOLLAR' function is fully equivalent to the body of 'CreateRULE_OBJECTTYPE_DOLLARTEXTDOLLAR' function. NCCache NCQLParserRule.cs 72