### PR TITLE
Fix V3022

### DIFF
--- a/Src/NCCommon/Util/ServiceConfiguration.cs
+++ b/Src/NCCommon/Util/ServiceConfiguration.cs
@@ -475,7 +475,7 @@ namespace Alachisoft.NCache.Common.Util
                 {
                     tempInt = Int32.Parse(config.AppSettings.Settings["NCacheServer.ForcedGCThreshold"].Value);
 
-                    if (tempInt > 0 || tempInt < 100)
+                    if (tempInt > 0 && tempInt < 100)
                         ForcedGCThreshold = tempInt;
                 }
             }


### PR DESCRIPTION
Another bug fixes from Pinguem.ru competition found with PVS-Studio:

- Expression 'tempInt > 0 || tempInt < 100' is always true. Probably the '&&' operator should be used here. NCCommon ServiceConfiguration.cs 478