### PR TITLE
Fix V3043

### DIFF
--- a/Src/NCManagement/Management/HostServer.cs
+++ b/Src/NCManagement/Management/HostServer.cs
@@ -452,9 +452,10 @@ namespace Alachisoft.NCache.Management
                 LeasedCache cache = cacheInfo.Cache;
                 if (cache != null)
                 {
-                    if (cache.IsRunning)
+                    if (cache.IsRunning) {
                         status.Status = CacheStatus.Running;
                         status.IsCoordinator = cache.IsCoordinator;
+                    }
                 }
             }
             return status;


### PR DESCRIPTION
Another bug fixes from Pinguem.ru competition found with PVS-Studio:

-  The code's operational logic does not correspond with its formatting. The statement is indented to the right, but it is always executed. It is possible that curly brackets are missing. NCManagement HostServer.cs 457