### PR TITLE
Fix V3043

### DIFF
--- a/Src/NCSocketServer/SocketServer/Util/KeyPackageBuilder.cs
+++ b/Src/NCSocketServer/SocketServer/Util/KeyPackageBuilder.cs
@@ -153,7 +153,7 @@ namespace Alachisoft.NCache.SocketServer.Util
             if (dic != null && dic.Count > 0) 
             {
                 if (keyPackageResponse == null)
-                    keyPackageResponse = new Alachisoft.NCache.Common.Protobuf.KeyValuePackageResponse(); ;
+                    keyPackageResponse = new Alachisoft.NCache.Common.Protobuf.KeyValuePackageResponse();
 
                 IDictionaryEnumerator enu = dic.GetEnumerator();
                 while (enu.MoveNext())


### PR DESCRIPTION
 Another bug fixes from Pinguem.ru competition found with PVS-Studio:

- The code's operational logic does not correspond with its formatting. The statement is indented to the right, but it is always executed. It is possible that curly brackets are missing. NCSocketServer KeyPackageBuilder.cs 156