### PR TITLE
Fix V3070

### DIFF
--- a/Src/NCManagement/Management/ClientConfiguration/ClientConfigManager.cs
+++ b/Src/NCManagement/Management/ClientConfiguration/ClientConfigManager.cs
@@ -36,11 +36,11 @@ namespace Alachisoft.NCache.Management.ClientConfiguration
     class ClientConfigManager
     {
         static ArrayList ipAddresses = new ArrayList(1);
+
+        static string DIRNAME = "Config";
+        static string FILENAME = "client.ncconf";
         static string c_configDir = DIRNAME;
         static string c_configFileName = FILENAME;
-        static string DIRNAME = "Config";
-
-        static string FILENAME = "client.ncconf";
 
         internal static string ENDSTRING = "\r\n";
         static string bindIp;


### PR DESCRIPTION
Another bug fixes from Pinguem.ru competition found with PVS-Studio:

-  Uninitialized variable 'DIRNAME' is used when initializing the 'c_configDir' variable. NCManagement ClientConfigManager.cs 39

-  Uninitialized variable 'FILENAME' is used when initializing the 'c_configFileName' variable. NCManagement ClientConfigManager.cs 40