### PR TITLE
Fix V3070

### DIFF
--- a/Src/NCManagement/Management/MappingConfiguration/MappingConfigurationManager.cs
+++ b/Src/NCManagement/Management/MappingConfiguration/MappingConfigurationManager.cs
@@ -24,11 +24,12 @@ using Alachisoft.NCache.Config;
 namespace Alachisoft.NCache.Management.MappingConfiguration
 {
     public class MappingConfigurationManager
-    {
-        static string m_configDir = DIRNAME;
-        static string m_configFileName = FILENAME;
+    { 
         static string DIRNAME = "Config";
         static string FILENAME = "server-end-point.ncconf";
+        static string m_configDir = DIRNAME;
+        static string m_configFileName = FILENAME;
+        
         private static object _syncRoot = new object();
 
         private static void CombinePath()


### PR DESCRIPTION
Another bug fixes from Pinguem.ru competition found with PVS-Studio:

- Uninitialized variable 'DIRNAME' is used when initializing the 'm_configDir' variable. NCManagement MappingConfigurationManager.cs 28

- Uninitialized variable 'FILENAME' is used when initializing the 'm_configFileName' variable. NCManagement MappingConfigurationManager.cs 29