### PR TITLE
Fix V3118

### DIFF
--- a/Src/NCCommon/Util/AppUtil.cs
+++ b/Src/NCCommon/Util/AppUtil.cs
@@ -277,7 +277,7 @@ namespace Alachisoft.NCache.Common
         {
             dt = dt.ToUniversalTime();
             TimeSpan interval = dt - START_DT;
-            return (int)interval.Milliseconds;
+            return (int)interval.TotalMilliseconds;
         }
 
         public static long DiffTicks(DateTime dt)


### PR DESCRIPTION
Another bug fixes from Pinguem.ru competition found with PVS-Studio:

*  Milliseconds component of 'interval' is used, which does not represent full time interval. Possibly 'TotalMilliseconds' value was intended instead. NCCommon AppUtil.cs 280