### PR TITLE
Fix V3127

### DIFF
--- a/Src/NCCache/Caching/CallbackEntry.cs
+++ b/Src/NCCache/Caching/CallbackEntry.cs
@@ -284,7 +284,7 @@ namespace Alachisoft.NCache.Caching
                 }
                 if (_itemUpdateListener != null)
                 {
-                    temp += _itemRemovedListener.Count * Common.MemoryUtil.NetListOverHead;
+                    temp += _itemUpdateListener.Count * Common.MemoryUtil.NetListOverHead;
                     foreach (CallbackInfo cbInfo in _itemUpdateListener)
                     {
                         temp += cbInfo.Size;


### PR DESCRIPTION
 Another bug fixes from Pinguem.ru competition found with PVS-Studio:

- Two similar code fragments were found. Perhaps, this is a typo and '_itemUpdateListener' variable should be used instead of '_itemRemovedListener' NCCache CallbackEntry.cs 287