### PR TITLE
Fix V3127

### DIFF
--- a/Src/NCCluster/Protocols/PingRsp.cs
+++ b/Src/NCCluster/Protocols/PingRsp.cs
@@ -98,7 +98,7 @@ namespace Alachisoft.NGroups.Protocols
 				oe = (own_addr == rsp.own_addr);
 
 			bool ce = false;
-			if(own_addr != null)
+			if(coord_addr != null)
 			{
 				ce = coord_addr.Equals(rsp.coord_addr);
 			}


### PR DESCRIPTION
 Another bug fixes from Pinguem.ru competition found with PVS-Studio:

- Two similar code fragments were found. Perhaps, this is a typo and 'coord_addr' variable should be used instead of 'own_addr' NCCluster PingRsp.cs 101